### PR TITLE
Fix so that when the type is an array of types, falsey values are not…

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function filterObjectOnSchema(schema, doc){
           else if(sp.type == 'boolean' || sp.type == 'number' || sp.type == 'integer'){
             if(doc[key] != null && typeof doc[key] != 'undefined') results[key] = doc[key];
           }else{
-            if (doc[key]) results[key] = doc[key];
+            if (doc[key] != undefined && doc[key] != null) results[key] = doc[key];
           }
         }
       });

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function filterObjectOnSchema(schema, doc){
     //console.log("DOC: ", JSON.stringify(doc, null, 2));
     //console.log("SCH: ", JSON.stringify(schema, null, 2));
 
-    if (schema.type == 'object') {
+    if (schema.type === 'object') {
       results = {};   // holds this levels items
 
       if (!schema.properties) {
@@ -27,7 +27,7 @@ function filterObjectOnSchema(schema, doc){
       Object.keys(schema.properties).forEach(function(key){
         if (doc[key] !== undefined){
           var sp = schema.properties[key];
-          if ( sp.type == 'object'){
+          if ( sp.type === 'object'){
 
             // check if property-less object (free-form)
             if (sp.hasOwnProperty('properties')){
@@ -42,20 +42,20 @@ function filterObjectOnSchema(schema, doc){
               }
             }
 
-          }else if(sp.type == 'array'){
+          }else if(sp.type === 'array'){
             if (doc[key]) results[key] = filterObjectOnSchema(sp, doc[key]);
           }
-          else if(sp.type == 'boolean' || sp.type == 'number' || sp.type == 'integer'){
+          else if(sp.type === 'boolean' || sp.type === 'number' || sp.type === 'integer'){
             if(doc[key] != null && typeof doc[key] != 'undefined') results[key] = doc[key];
           }else{
-            if (doc[key] != undefined && doc[key] != null) results[key] = doc[key];
+            if (doc[key] !== undefined && doc[key] !== null) results[key] = doc[key];
           }
         }
       });
 
-    } else if (schema.type == 'array'){
+    } else if (schema.type === 'array'){
       // arrays can hold objects or literals
-      if (schema.items.type == 'object' && Array.isArray(doc)) {
+      if (schema.items.type === 'object' && Array.isArray(doc)) {
         results = [];
         doc.forEach(function (item) {
           results.push(filterObjectOnSchema(schema.items, item));

--- a/test/test.js
+++ b/test/test.js
@@ -49,6 +49,9 @@ describe('json-schema-filter', function(){
         "items": {
           "type": "string"
         }
+      },
+      "boolField":{
+        "type": ["boolean", "null"]
       }
     },
     "required": ["firstName", "lastName"]
@@ -161,6 +164,18 @@ describe('json-schema-filter', function(){
     var result = filter(schema, document);
 
     expect(result).to.eql({firstName: 'Andrew', contacts: 123});
+  });
+
+  it('does not filter falsey types when type is an array of types', function() {
+    var document = {
+      firstName: 'Andrew',
+      contacts: 123,
+      boolField: false
+    }
+
+    var result = filter(schema, document);
+
+    expect(result).to.eql({firstName: 'Andrew', contacts: 123, boolField: false});
   });
 
 });


### PR DESCRIPTION
Fix so that when the type is an array of types, falsey values are not filtered out

For example, the schema is {"type": ["boolean", "null"]}. We don't want a value of "isFromUser": false to be filtered out.